### PR TITLE
make mingw happy

### DIFF
--- a/highgui/src/display_win32.cpp
+++ b/highgui/src/display_win32.cpp
@@ -43,7 +43,7 @@ static inline void safeReleaseArray(T* &array) {
 	array = nullptr;
 }
 
-static LRESULT CALLBACK __globalWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK __globalWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	if (g_wndBeingCreated) {
 		g_wndBeingCreated->m_hWnd = hWnd;

--- a/highgui/src/display_win32.h
+++ b/highgui/src/display_win32.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <Windows.h>
+#include <windows.h>
 
 class SimpleWindow
 {
@@ -25,7 +25,7 @@ protected:
 	virtual LRESULT windowProc(UINT msg, WPARAM wParam, LPARAM lParam);
 
 public:
-	friend static LRESULT CALLBACK __globalWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+	friend LRESULT CALLBACK __globalWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
 	static double getDesktopDpiFactor();
 


### PR DESCRIPTION
Storage class specifiers are not allowed in friend declarations. Maybe it's a MSVC dialect.