### PR TITLE
fix http jpg streaming pthread stack smashing

### DIFF
--- a/highgui/src/writer_http.cpp
+++ b/highgui/src/writer_http.cpp
@@ -314,8 +314,8 @@ void writer_http_impl::mainloop()
         // handle client
         while (1)
         {
-            char buf[1024 * 1024];
-            client.recv(buf, 1024 * 1024 - 1);
+            char buf[4096] = {0};
+            client.recv(buf, sizeof(buf) - 1);
 
             // fprintf(stderr, "%s", buf);
             // fprintf(stderr, "-------------------------\n");


### PR DESCRIPTION
musl only has a 128k default pthread stack size, `char buf[1024x1024]` will corrupt the memory

may or may not fixes #210 